### PR TITLE
Feature/scan performance

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -3,19 +3,18 @@ var senateData;
 var perfStart = performance.now();
 
 function getRegExpString(senator) {
-  var title = '(Senator|((?!([A-Z0-9])).|^)Sen.|Congressman|Congresswoman)\\s*';
-  var optionalTitle = '(' + title + ')?';
+  var title = '(Senator|Sen\\.|Congressman|Congresswoman)';
   var optionalQuote = '(\'|")?';
   var wildCardMiddle = optionalQuote + '(\\w*)(\\.)?' + optionalQuote;
   var upToTwoWildCardMiddles = '\\s*' + wildCardMiddle + '\\s*' + wildCardMiddle + '\\s*';
-  var firstLast = optionalTitle + '\\b' + senator.firstName + '\\b' + upToTwoWildCardMiddles + '\\b' + senator.lastName + '\\b';
-  var lastFirst = '\\b' + senator.lastName + ',\\s*' + senator.firstName + '\\b';
-  var titleLast = title + '\\b' + senator.lastName + '\\b';
+  var firstLast = '\\b' + senator.firstName + '\\b' + upToTwoWildCardMiddles + '\\b' + senator.lastName + '\\b';
+  var lastFirst = '\\b' + senator.lastName + ',\\b' + senator.firstName + '\\b';
+  var titleLast = '\\b' + title + '\\s*' + senator.lastName + '\\b';
   var nicknames = '';
   var regExpString = '';
 
   function getNicknameString (nickname, lastName) {
-    return '|' + optionalTitle + '\\b' + nickname + '\\b' + upToTwoWildCardMiddles + '\\b' + lastName + '\\b|\\b' + lastName + '\\b,\\b' + nickname + '\\b';
+    return '|\\b' + nickname + '\\b' + upToTwoWildCardMiddles + '\\b' + lastName + '\\b|\\b' + lastName + '\\b,\\b' + nickname + '\\b';
   }
 
   if (senator.nicknames) {
@@ -28,7 +27,7 @@ function getRegExpString(senator) {
     }
   }
 
-  regExpString += firstLast + '|' + lastFirst + '|' + titleLast + nicknames;
+  regExpString += title + '?' + '(' + firstLast + nicknames + ')|' + titleLast + '|' + lastFirst;
 
   return regExpString;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,10 @@ var $ = function(context) {
   this.ready = function() {}
 };
 
+var performance = {
+  now: function() {}
+};
+
 contentJavascript = fs.readFileSync(path.resolve(__dirname, '../js/content.js'),'utf8');
 eval(contentJavascript);
 
@@ -25,7 +29,7 @@ describe('getRegExpString', function() {
     ]
   };
 
-  var re = getRegExp(senator);
+  var re = new RegExp(getRegExpString(senator), 'ig');
 
   it('matches first, middle, and last name permutations', function() {
     expect('Bernard Sanders'.match(re).length).to.equal(1);


### PR DESCRIPTION
This uses @elgreg's suggestion to create a single, massive regular expression that combines all of the senator data/permutations. We do a single pass through the DOM with MarkJS, highlighting all matches.

Previously, I was adding a tooltip for every match using the MarkJS each callback. Now, instead, I've added a ```mouseenter``` event listener to each match, and we build the tooltip on demand. This requires an additional run through all permutations, but because the text to match is so small, it's extremely performant. In testing, I notice no delay between hovering and the display of the tooltip.

The gains are substantial. Testing on [Wikipedia's list of Senators](https://en.wikipedia.org/wiki/List_of_current_United_States_Senators), the old way took ~16.58s to scan the DOM with all senator data. The new way takes only ~2.25s, or 13.6% of the time.

The downside is that during MarkJS processing I've noticed slowdowns. It even seems to interrupt Chrome's paint cycles, so that if the user scrolls quickly on a page that is still being processed, they may not see content that's further down the page until MarkJS is done.