### PR TITLE
Increase performance by searching for last names first

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -33,43 +33,44 @@ function getRegExpString(senator) {
 }
 
 function getLastNamesRegExp() {
-  var lastNamesRegExpString = '';
+  var lastNamesRegExpArr = [];
 
   for (var i = 0; i < senateData.length; i++) {
-    var divider = lastNamesRegExpString.length == 0 ? '' : '|';
-    lastNamesRegExpString += divider + '\\b' + senateData[i].lastName + '\\b';
+    lastNamesRegExpArr.push('\\b' + senateData[i].lastName + '\\b');
   }
 
-  return new RegExp(lastNamesRegExpString, 'ig');
+  return new RegExp(lastNamesRegExpArr.join('|'), 'ig');
 }
 
 function scan() {
   var lastNamesRegExp = getLastNamesRegExp();
   var foundLastNames = dedupeArray(document.body.innerText.match(lastNamesRegExp));
-  var foundLastNamesRegExpString = '';
+  var foundLastNamesRegExpArr = [];
+  var foundLastNamesRegExp;
 
   for (var i = 0; i < senateData.length; i++) {
     if (foundLastNames.indexOf(senateData[i].lastName) > -1) {
-      var divider = foundLastNamesRegExpString.length == 0 ? '' : '|';
-      var senatorRegEx = getRegExpString(senateData[i]);
-      foundLastNamesRegExpString += divider + '(' + senatorRegEx + ')';
+      var senatorRegEx = '(' + getRegExpString(senateData[i]) + ')';
+      foundLastNamesRegExpArr.push(senatorRegEx);
     }
   }
 
-  var foundLastNamesRegExp = new RegExp(foundLastNamesRegExpString, 'ig');
+  if (foundLastNamesRegExpArr.length) {
+    foundLastNamesRegExp = new RegExp(foundLastNamesRegExpArr.join('|'), 'ig');
 
-  mark.markRegExp(foundLastNamesRegExp, {
-    element: 'span',
-    className: 'dial-congress',
-    done: function(x) {
-      var perfEnd = performance.now();
-      var perfTime = Math.round(perfEnd - perfStart) / 1000;
-      console.log('Dial Congress scan of DOM complete: ' + perfTime + ' seconds');
-      console.log('Congress critters found: ' + x);
-    }
-  });
+    mark.markRegExp(foundLastNamesRegExp, {
+      element: 'span',
+      className: 'dial-congress',
+      done: function(x) {
+        var perfEnd = performance.now();
+        var perfTime = Math.round(perfEnd - perfStart) / 1000;
+        console.log('Dial Congress scan of DOM complete: ' + perfTime + ' seconds');
+        console.log('Congress critters found: ' + x);
+      }
+    });
 
-  bindHoverEvents();
+    bindHoverEvents();
+  }
 }
 
 function bindHoverEvents() {


### PR DESCRIPTION
@elgreg check this out. Doing the search for last names first, and constructing the full-DOM scan's regex from only senators with found last names, results generally in superior performance gains. Most websites are only gonna have a handful of senators listed, so our full scan will be drastically simpler.

Gains go down the more last names that are found. So, for example, the [Wikipedia List of Senators](https://en.wikipedia.org/wiki/List_of_current_United_States_Senators) will take the same amount of time as the previous code, because we're still using the massive regexp of all senators.

I'm also doing the initial search for last names with a simple match() call to the text of ```document.body```, so the initial search is probably about as fast as we'll get it. Doing the other ideas (wrapping found last names first, then searching text before and after) would require too much other DOM processing. We'd have to look at the parent of the wrapped last names, and also remove the temporary wrapping. In initial testing, I found this would decrease performance overall.