### PR TITLE
Mitigate positives when shorter overlapping text matches first

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,8 @@ describe('getRegExpString', function() {
 
 
   it('matches first, middle, nickname, and last name permutations', function() {
-    var re = new RegExp(getRegExpString(mockCritter), 'ig');
+    var regExpString = getRegExpStrings(mockCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
     var permutations = [];
 
     var firstName = mockCritter.firstName;
@@ -59,7 +60,8 @@ describe('getRegExpString', function() {
 
 
   it('matches name permutations with quoted nicknames', function() {
-    var re = new RegExp(getRegExpString(mockCritter), 'ig');
+    var regExpString = getRegExpStrings(mockCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
     var permutations = [];
 
     var firstName = mockCritter.firstName;
@@ -88,7 +90,8 @@ describe('getRegExpString', function() {
 
 
   it('matches middle initials', function() {
-    var re = new RegExp(getRegExpString(mockCritter), 'ig');
+    var regExpString = getRegExpStrings(mockCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
     var permutations = [];
 
     var firstName = mockCritter.firstName;
@@ -119,7 +122,8 @@ describe('getRegExpString', function() {
     var mockSenator = _.cloneDeep(mockCritter);
     mockSenator.house = 'senate';
 
-    var re = new RegExp(getRegExpString(mockSenator), 'ig');
+    var regExpString = getRegExpStrings(mockSenator);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
     var permutations = [];
     var titles = ['Senator','Sen.','Congressman','Congresswoman'];
 
@@ -149,7 +153,8 @@ describe('getRegExpString', function() {
     var mockRep = _.cloneDeep(mockCritter);
     mockRep.house = 'house';
 
-    re = new RegExp(getRegExpString(mockRep), 'ig');
+    regExpString = getRegExpStrings(mockRep);
+    re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
     permutations = [];
     titles = ['Representative','Rep.','Congressman','Congresswoman'];
 
@@ -179,7 +184,8 @@ describe('getRegExpString', function() {
       'lastName': 'Cárdenas'
     };
 
-    var re = new RegExp(getRegExpString(mockAccentCritter), 'ig');
+    var regExpString = getRegExpStrings(mockAccentCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
     var permutations = [
       'André Cárdenas',
       'André Cardenas',
@@ -199,7 +205,8 @@ describe('getRegExpString', function() {
       'lastName': 'O\'Rourke'
     };
 
-    var re = new RegExp(getRegExpString(mockApostropheCritter), 'ig');
+    var regExpString = getRegExpStrings(mockApostropheCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
     var permutations = [
       'Jim O\'Rourke',
       'Jim O’Rourke'
@@ -213,14 +220,16 @@ describe('getRegExpString', function() {
 
   it('matches multiple occurences', function() {
     var string = 'In one of the oddest protests ever conceived, feminist women everywhere are getting tattoos of a phrase uttered by Sen. Mitch McConnell (R-KY) in order to show their disdain for President Trump. “Every single women has had a Mitch McConnell or 10 or 20 in her life trying to tell her how to be and what to do,” said Nora McInerny, a 34-year-old author and blogger who triggered the tattoo trend with an accidental public Facebook post. Addison Mitchell "Mitch" McConnell, Jr. (born February 20, 1942) is an American politician and the senior United States Senator from Kentucky.';
-    var re = new RegExp(getRegExpString(mockCritter), 'ig');
+    var regExpString = getRegExpStrings(mockCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
 
     expect(string.match(re).length).to.equal(3);
   });
 
 
   it('does not match single names on their own', function() {
-    var re = new RegExp(getRegExpString(mockCritter), 'ig');
+    var regExpString = getRegExpStrings(mockCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
 
     expect('Addison'.match(re)).to.be.null;
     expect('McConnell'.match(re)).to.be.null;
@@ -232,7 +241,8 @@ describe('getRegExpString', function() {
 
 
   it('does not match misspellings', function() {
-    var re = new RegExp(getRegExpString(mockCritter), 'ig');
+    var regExpString = getRegExpStrings(mockCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
 
     expect('Match McConnell'.match(re)).to.be.null;
     expect('Addison McCornell'.match(re)).to.be.null;
@@ -240,14 +250,16 @@ describe('getRegExpString', function() {
 
 
   it('does not match abbreviated "sen." at end of previous sentence', function() {
-    var re = new RegExp(getRegExpString(mockCritter), 'ig');
+    var regExpString = getRegExpStrings(mockCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
 
     expect('He wore the nicest lederhosen. McConnell said some things.'.match(re)).to.be.null;
   });
 
 
   it('enforces spaces between names', function() {
-    var re = new RegExp(getRegExpString(mockCritter), 'ig');
+    var regExpString = getRegExpStrings(mockCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
 
     expect('Notmitch McConnell'.match(re)).to.be.null;
     expect('Addison McConnellnot'.match(re)).to.be.null;
@@ -264,7 +276,8 @@ describe('getRegExpString', function() {
         'G.K.'
       ]
     };
-    var re = new RegExp(getRegExpString(punctuatedCritter), 'ig');
+    var regExpString = getRegExpStrings(punctuatedCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
 
     expect('G.K. Butterfield'.match(re).length).to.equal(1);
     expect('G. K. Butterfield'.match(re).length).to.equal(1);
@@ -272,7 +285,8 @@ describe('getRegExpString', function() {
 
 
   it('matches if there is excessive white space between names', function() {
-    var re = new RegExp(getRegExpString(mockCritter), 'ig');
+    var regExpString = getRegExpStrings(mockCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
 
     expect('Mitch     McConnell'.match(re).length).to.equal(1);
     expect('  Addison  Mitchy     McConnell'.match(re).length).to.equal(1);


### PR DESCRIPTION
Given two senators as follows:

```
[
  {
    firstName: "Abe",
    lastName: "Smith"
  },
  {
    firstName: "Smith",
    lastName: "Lawmaker"
  }
]
```

The text " Lawmaker" originally matched incorrectly to "Abe
Smith", since that shorter match of title and last name was found first while
iterating over the congress data during the tooltip build.

To fix, we can sort all possible reg ex strings by length, descending. That
way, longer strings will be checked first. This is achieved by building all of
the regular expression strings ahead of time. In addition to storing an array
of strings on each congress person's data object, we create a separate array
of objects containing a single regular expression and an index linking it back
to the original congress data.

Now, when a matched name is hovered over, we can search the new array of
regular expression objects, which has been sorted in descending order by
length. Additionally, we save later processing time by not having to rebuild
reg expression strings during future DOM injections.

Fixes #13.