### PR TITLE
Feature/senate middle naming

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -43,12 +43,12 @@ function getRegExpStrings(critter) {
   namePermutations += '(' + firstNames.join('|') + ')\\s+';
 
   if (combinedMiddleNames && combinedMiddleNames.length) {
-    var middleNameCombos = '((' + combinedMiddleNames.join('|') + ')\\s+)?';
+    var middleNameCombos = '((' + combinedMiddleNames.join('\\s+|') + '\\s+){0,2})?';
     namePermutations += middleNameCombos;
   }
 
   var lastName = prepName(critter.lastName);
-  var optionalSuffix = critter.suffix ? ',?\\s+' + critter.suffix + '\\.?' : '';
+  var optionalSuffix = critter.suffix ? '(,?\\s+' + critter.suffix + '\\.?)?' : '';
 
   namePermutations += lastName + optionalSuffix;
   regExStrings.push('\\b(' + namePermutations + ')\\b');

--- a/js/content.js
+++ b/js/content.js
@@ -47,7 +47,7 @@ function getRegExpStrings(critter) {
     namePermutations += middleNameCombos;
   }
 
-  var lastName = prepName(critter.lastName);
+  var lastName = prepLastName(critter.lastName);
   var optionalSuffix = critter.suffix ? '(,?\\s+' + critter.suffix + '\\.?)?' : '';
 
   namePermutations += lastName + optionalSuffix;
@@ -118,6 +118,31 @@ function prepName(name) {
 
 
 /**
+ * Preps the last name for permutations due to multiple words. Logic is set to
+ * first look for the full last name with a space or a hyphen, or  alternatively
+ * for each last name alone.
+ * @param {string} name The last name.
+ * @return {string} A regex string containing potential last name permutations.
+ */
+function prepLastName(name) {
+  var preppedName = prepName(name.replace(' ', '(\\s+|-)'));
+  var splitNames = name.split(' ');
+
+  if (splitNames.length == 1) {
+    return preppedName;
+  } else {
+    var preppedSplitNames = _.map(splitNames, function(splitName) {
+      return prepName(splitName);
+    });
+
+    var finalPreppedLastName =  '(' + preppedName + '|(' + preppedSplitNames.join('|') + '))';
+
+    return finalPreppedLastName;
+  };
+}
+
+
+/**
  * Builds a regex of all congressperson's last names, to provide an initial
  * searching mechanism that is less processor intensive than searching for all
  * name permutations of each congressperson.
@@ -127,7 +152,11 @@ function getLastNamesRegExp() {
   var lastNamesRegExpArr = [];
 
   for (var i = 0; i < congressData.length; i++) {
-    lastNamesRegExpArr.push(prepName(congressData[i].lastName));
+    var splitLastNames = congressData[i].lastName.split(' ');
+
+    splitLastNames.forEach(function(lastName) {
+      lastNamesRegExpArr.push(prepName(lastName));
+    });
   }
 
   var lastNamesRegExpString = stringifyRegExpStrings(_.uniq(lastNamesRegExpArr));
@@ -154,7 +183,7 @@ function getOriginalLastNames(lastNames) {
 
   lastNames.forEach(function(lastName) {
     for (var i = 0; i < congressData.length; i++) {
-      var regExpString = prepName(congressData[i].lastName);
+      var regExpString = prepLastName(congressData[i].lastName);
       var re = new RegExp(regExpString, 'ig');
 
       if (lastName.match(re)) {

--- a/js/content.js
+++ b/js/content.js
@@ -48,14 +48,15 @@ function getRegExpStrings(critter) {
   }
 
   var lastName = prepName(critter.lastName);
-  namePermutations += lastName;
+  var optionalSuffix = critter.suffix ? ',?\\s+' + critter.suffix + '\\.?' : '';
+
+  namePermutations += lastName + optionalSuffix;
   regExStrings.push('\\b(' + namePermutations + ')\\b');
 
   var titleLast = title + '\\s+' + lastName;
   regExStrings.push('\\b(' + titleLast + ')\\b');
 
-  var optionalJr = critter.junior ? ',?\\s+Jr\\.?' : '';
-  var lastFirst = lastName + optionalJr + ',\\s+(' + firstNames.join('|') + ')';
+  var lastFirst = lastName + optionalSuffix + ',\\s+(' + firstNames.join('|') + ')';
   regExStrings.push('\\b(' + lastFirst + ')\\b');
 
   return regExStrings;

--- a/js/house.js
+++ b/js/house.js
@@ -280,7 +280,7 @@ var houseData = [
   {
     "lastName": "Bishop",
     "firstName": "Sanford",
-    "junior": true,
+    "suffix": "Jr",
     "party": "D",
     "middleNames": [
       "Dixon"
@@ -761,7 +761,7 @@ var houseData = [
     "nicknames": [
       "Lacy"
     ],
-    "junior": true,
+    "suffix": "Jr",
     "party": "D",
     "middleNames": [
       "Lacy"
@@ -904,7 +904,7 @@ var houseData = [
   {
     "lastName": "Conyers",
     "firstName": "John",
-    "junior": true,
+    "suffix": "Jr",
     "party": "D",
     "middleNames": [
       "James"
@@ -1336,7 +1336,7 @@ var houseData = [
     "nicknames": [
       "Jimmy",
     ],
-    "junior": true,
+    "suffix": "Jr",
     "party": "R",
     "middleNames": [
       "James"
@@ -1632,7 +1632,7 @@ var houseData = [
     "nicknames": [
       "Tom"
     ],
-    "junior": true,
+    "suffix": "Jr",
     "party": "R",
     "middleNames": [
       "Alexander"
@@ -2255,7 +2255,7 @@ var houseData = [
   {
     "lastName": "Jones",
     "firstName": "Walter",
-    "junior": true,
+    "suffix": "Jr",
     "party": "R",
     "middleNames": [
       "Beaman"
@@ -3397,7 +3397,7 @@ var houseData = [
   {
     "lastName": "Pallone",
     "firstName": "Frank",
-    "junior": true,
+    "suffix": "Jr",
     "party": "D",
     "middleNames": [
       "Joseph"
@@ -3434,7 +3434,7 @@ var houseData = [
     "nicknames": [
       "Bill"
     ],
-    "junior": true,
+    "suffix": "Jr",
     "party": "D",
     "middleNames": [
       "James"
@@ -3455,7 +3455,7 @@ var houseData = [
   {
     "lastName": "Payne",
     "firstName": "Donald",
-    "junior": true,
+    "suffix": "Jr",
     "party": "D",
     "middleNames": [
       "Milford"

--- a/js/senate.js
+++ b/js/senate.js
@@ -394,13 +394,11 @@ senateData = [
     "party": "R",
     "firstName": "Addison",
     "lastName": "McConnell",
-    "suffix": "Jr",
-    "middleNames": [
-      "Mitchell"
-    ],
     "nicknames": [
+      "Mitchell",
       "Mitch"
     ],
+    "suffix": "Jr",
     "state": "KY",
     "middleNames": [],
     "phone": "(202) 224-2541"
@@ -585,10 +583,12 @@ senateData = [
   },
   {
     "party": "D",
-    "firstName": "Jon",
+    "firstName": "Jonathan",
     "lastName": "Tester",
     "state": "MT",
-    "middleNames": [],
+    "nicknames": [
+      "Jon"
+    ],
     "phone": "(202) 224-2644"
   },
   {

--- a/js/senate.js
+++ b/js/senate.js
@@ -26,6 +26,7 @@ senateData = [
     "party": "R",
     "firstName": "Luther",
     "lastName": "Strange",
+    "suffix": "III",
     "state": "AL",
     "middleNames": [
       "Johnson"
@@ -85,6 +86,7 @@ senateData = [
     "party": "R",
     "firstName": "John",
     "lastName": "McCain",
+    "suffix": "III",
     "state": "AZ",
     "middleNames": [
       "Sidney"
@@ -186,6 +188,7 @@ senateData = [
     "party": "D",
     "firstName": "Clarence",
     "lastName": "Nelson",
+    "suffix": "II",
     "nicknames": [
       "Bill"
     ],
@@ -209,6 +212,7 @@ senateData = [
     "party": "R",
     "firstName": "David",
     "lastName": "Perdue",
+    "suffix": "Jr",
     "nicknames": [
       "Dave"
     ],
@@ -390,6 +394,7 @@ senateData = [
     "party": "R",
     "firstName": "Addison",
     "lastName": "McConnell",
+    "suffix": "Jr",
     "middleNames": [
       "Mitchell"
     ],
@@ -463,6 +468,7 @@ senateData = [
     "party": "D",
     "firstName": "Christopher",
     "lastName": "Van Hollen",
+    "suffix": "Jr",
     "nicknames": [
       "Chris"
     ],
@@ -628,6 +634,7 @@ senateData = [
     "party": "R",
     "firstName": "John",
     "lastName": "Hoeven",
+    "suffix": "III",
     "state": "ND",
     "middleNames": [
       "Henry"
@@ -960,6 +967,7 @@ senateData = [
     "party": "R",
     "firstName": "Robert",
     "lastName": "Corker",
+    "suffix": "Jr",
     "nicknames": [
       "Bob"
     ],
@@ -973,6 +981,7 @@ senateData = [
     "party": "R",
     "firstName": "Andrew",
     "lastName": "Alexander",
+    "suffix": "Jr",
     "nicknames": [
       "Lamar"
     ],
@@ -996,6 +1005,7 @@ senateData = [
     "party": "R",
     "firstName": "John",
     "lastName": "Cornyn",
+    "suffix": "III",
     "state": "TX",
     "middleNames": [],
     "phone": "(202) 224-2934"
@@ -1121,6 +1131,7 @@ senateData = [
     "party": "D",
     "firstName": "Joseph",
     "lastName": "Manchin",
+    "suffix": "III",
     "nicknames": [
       "Joe"
     ],
@@ -1142,6 +1153,7 @@ senateData = [
     "party": "R",
     "firstName": "John",
     "lastName": "Barrasso",
+    "suffix": "III",
     "state": "WY",
     "middleNames": [
       "Anthony"

--- a/js/senate.js
+++ b/js/senate.js
@@ -497,14 +497,13 @@ senateData = [
   {
     "party": "D",
     "firstName": "Deborah",
-    "lastName": "Stabenow",
+    "lastName": "Greer Stabenow",
     "nicknames": [
       "Debbie"
     ],
     "state": "MI",
     "middleNames": [
-      "Ann",
-      "Greer"
+      "Ann"
     ],
     "phone": "(202) 224-4822"
   },
@@ -696,14 +695,11 @@ senateData = [
   {
     "party": "D",
     "firstName": "Margaret",
-    "lastName": "Hassan",
+    "lastName": "Wood Hassan",
     "nicknames": [
       "Maggie"
     ],
     "state": "NH",
-    "middleNames": [
-      "Wood"
-    ],
     "phone": "(202) 224-3324"
   },
   {
@@ -1142,7 +1138,7 @@ senateData = [
   {
     "party": "R",
     "firstName": "Shelley",
-    "lastName": "Capito",
+    "lastName": "Moore Capito",
     "state": "WV",
     "middleNames": [
       "Wellons"

--- a/js/senate.js
+++ b/js/senate.js
@@ -72,7 +72,9 @@ senateData = [
     "firstName": "John",
     "lastName": "McCain",
     "state": "AZ",
-    "middleNames": [],
+    "middleNames": [
+      "Sidney"
+    ],
     "phone": "(202) 224-2235"
   },
   {

--- a/js/senate.js
+++ b/js/senate.js
@@ -502,7 +502,7 @@ senateData = [
     ],
     "state": "MI",
     "middleNames": [
-      "Ann"
+      "Ann",
       "Greer"
     ],
     "phone": "(202) 224-4822"
@@ -576,11 +576,8 @@ senateData = [
     "lastName": "Cochran",
     "nicknames": [
       "Thad"
-    ]
-    "state": "MS",
-    "middleNames": [
-      "Thad"
     ],
+    "state": "MS",
     "phone": "(202) 224-5054"
   },
   {
@@ -765,8 +762,8 @@ senateData = [
     "lastName": "Cortez Masto",
     "state": "NV",
     "middleNames": [
-    "Marie",
-  ]
+      "Marie"
+    ],
     "phone": "(202) 224-3542"
   },
   {

--- a/js/senate.js
+++ b/js/senate.js
@@ -881,6 +881,7 @@ senateData = [
     "party": "D",
     "firstName": "Robert",
     "lastName": "Casey",
+    "suffix": "Jr",
     "nicknames": [
       "Bob"
     ],

--- a/js/senate.js
+++ b/js/senate.js
@@ -7,7 +7,9 @@ senateData = [
       "Dan"
     ],
     "state": "AK",
-    "middleNames": [],
+    "middleNames": [
+      "Scott"
+    ],
     "phone": "(202) 224-3004"
   },
   {
@@ -15,7 +17,9 @@ senateData = [
     "firstName": "Lisa",
     "lastName": "Murkowski",
     "state": "AK",
-    "middleNames": [],
+    "middleNames": [
+      "Ann"
+    ],
     "phone": "(202) 224-6665"
   },
   {
@@ -23,7 +27,9 @@ senateData = [
     "firstName": "Luther",
     "lastName": "Strange",
     "state": "AL",
-    "middleNames": [],
+    "middleNames": [
+      "Johnson"
+    ],
     "phone": "(202) 224-4124"
   },
   {
@@ -34,7 +40,9 @@ senateData = [
       "Dick"
     ],
     "state": "AL",
-    "middleNames": [],
+    "middleNames": [
+      "Craig"
+    ],
     "phone": "(202) 224-5744"
   },
   {
@@ -45,7 +53,9 @@ senateData = [
       "Tom"
     ],
     "state": "AR",
-    "middleNames": [],
+    "middleNames": [
+      "Bryant"
+    ],
     "phone": "(202) 224-2353"
   },
   {
@@ -53,7 +63,9 @@ senateData = [
     "firstName": "John",
     "lastName": "Boozman",
     "state": "AR",
-    "middleNames": [],
+    "middleNames": [
+      "Nichols"
+    ],
     "phone": "(202) 224-4843"
   },
   {
@@ -64,7 +76,9 @@ senateData = [
       "Jeff"
     ],
     "state": "AZ",
-    "middleNames": [],
+    "middleNames": [
+      "Lane"
+    ],
     "phone": "(202) 224-4521"
   },
   {
@@ -82,7 +96,10 @@ senateData = [
     "firstName": "Dianne",
     "lastName": "Feinstein",
     "state": "CA",
-    "middleNames": [],
+    "middleNames": [
+      "Goldman",
+      "Berman"
+    ],
     "phone": "(202) 224-3841"
   },
   {
@@ -90,7 +107,9 @@ senateData = [
     "firstName": "Kamala",
     "lastName": "Harris",
     "state": "CA",
-    "middleNames": [],
+    "middleNames": [
+      "Devi"
+    ],
     "phone": "(202) 224-3553"
   },
   {
@@ -98,7 +117,9 @@ senateData = [
     "firstName": "Cory",
     "lastName": "Gardner",
     "state": "CO",
-    "middleNames": [],
+    "middleNames": [
+      "Scott"
+    ],
     "phone": "(202) 224-5941"
   },
   {
@@ -106,7 +127,9 @@ senateData = [
     "firstName": "Michael",
     "lastName": "Bennet",
     "state": "CO",
-    "middleNames": [],
+    "middleNames": [
+      "Farrand"
+    ],
     "phone": "(202) 224-5852"
   },
   {
@@ -117,7 +140,9 @@ senateData = [
       "Chris"
     ],
     "state": "CT",
-    "middleNames": [],
+    "middleNames": [
+      "Scott"
+    ],
     "phone": "(202) 224-4041"
   },
   {
@@ -139,7 +164,9 @@ senateData = [
       "Tom"
     ],
     "state": "DE",
-    "middleNames": [],
+    "middleNames": [
+      "Richard"
+    ],
     "phone": "(202) 224-2441"
   },
   {
@@ -150,7 +177,9 @@ senateData = [
       "Chris"
     ],
     "state": "DE",
-    "middleNames": [],
+    "middleNames": [
+      "Andrew"
+    ],
     "phone": "(202) 224-5042"
   },
   {
@@ -158,11 +187,12 @@ senateData = [
     "firstName": "Clarence",
     "lastName": "Nelson",
     "nicknames": [
-      "William",
       "Bill"
     ],
     "state": "FL",
-    "middleNames": [],
+    "middleNames": [
+      "William"
+    ],
     "phone": "(202) 224-5274"
   },
   {
@@ -170,7 +200,9 @@ senateData = [
     "firstName": "Marco",
     "lastName": "Rubio",
     "state": "FL",
-    "middleNames": [],
+    "middleNames": [
+      "Antonio"
+    ],
     "phone": "(202) 224-3041"
   },
   {
@@ -181,7 +213,9 @@ senateData = [
       "Dave"
     ],
     "state": "GA",
-    "middleNames": [],
+    "middleNames": [
+      "Alfred"
+    ],
     "phone": "(202) 224-3521"
   },
   {
@@ -192,7 +226,9 @@ senateData = [
       "Johnny"
     ],
     "state": "GA",
-    "middleNames": [],
+    "middleNames": [
+      "Hardy"
+    ],
     "phone": "(202) 224-3643"
   },
   {
@@ -200,7 +236,9 @@ senateData = [
     "firstName": "Mazie",
     "lastName": "Hirono",
     "state": "HI",
-    "middleNames": [],
+    "middleNames": [
+      "Keiko"
+    ],
     "phone": "(202) 224-6361"
   },
   {
@@ -208,7 +246,9 @@ senateData = [
     "firstName": "Brian",
     "lastName": "Schatz",
     "state": "HI",
-    "middleNames": [],
+    "middleNames": [
+      "Emanuel"
+    ],
     "phone": "(202) 224-3934"
   },
   {
@@ -216,7 +256,9 @@ senateData = [
     "firstName": "Joni",
     "lastName": "Ernst",
     "state": "IA",
-    "middleNames": [],
+    "middleNames": [
+      "Kay"
+    ],
     "phone": "(202) 224-3254"
   },
   {
@@ -228,7 +270,9 @@ senateData = [
       "Chuck"
     ],
     "state": "IA",
-    "middleNames": [],
+    "middleNames": [
+      "Ernest"
+    ],
     "phone": "(202) 224-3744"
   },
   {
@@ -239,7 +283,9 @@ senateData = [
       "Jim"
     ],
     "state": "ID",
-    "middleNames": [],
+    "middleNames": [
+      "Elroy"
+    ],
     "phone": "(202) 224-2752"
   },
   {
@@ -250,7 +296,9 @@ senateData = [
       "Mike"
     ],
     "state": "ID",
-    "middleNames": [],
+    "middleNames": [
+      "Dean"
+    ],
     "phone": "(202) 224-6142"
   },
   {
@@ -261,7 +309,9 @@ senateData = [
       "Dick"
     ],
     "state": "IL",
-    "middleNames": [],
+    "middleNames": [
+      "Joseph"
+    ],
     "phone": "(202) 224-2152"
   },
   {
@@ -272,7 +322,9 @@ senateData = [
       "Tammy"
     ],
     "state": "IL",
-    "middleNames": [],
+    "middleNames": [
+      "Tammy"
+    ],
     "phone": "(202) 224-2854"
   },
   {
@@ -283,7 +335,9 @@ senateData = [
       "Joe"
     ],
     "state": "IN",
-    "middleNames": [],
+    "middleNames": [
+      "Simon"
+    ],
     "phone": "(202) 224-4814"
   },
   {
@@ -291,7 +345,9 @@ senateData = [
     "firstName": "Todd",
     "lastName": "Young",
     "state": "IN",
-    "middleNames": [],
+    "middleNames": [
+      "Christopher"
+    ],
     "phone": "(202) 224-5623"
   },
   {
@@ -302,7 +358,9 @@ senateData = [
       "Jerry"
     ],
     "state": "KS",
-    "middleNames": [],
+    "middleNames": [
+      "W"
+    ],
     "phone": "(202) 224-6521"
   },
   {
@@ -310,11 +368,12 @@ senateData = [
     "firstName": "Charles",
     "lastName": "Roberts",
     "nicknames": [
-      "Patrick",
       "Pat"
     ],
     "state": "KS",
-    "middleNames": [],
+    "middleNames": [
+      "Patrick"
+    ],
     "phone": "(202) 224-4774"
   },
   {
@@ -325,7 +384,9 @@ senateData = [
       "Rand"
     ],
     "state": "KY",
-    "middleNames": [],
+    "middleNames": [
+      "Howard"
+    ],
     "phone": "(202) 224-4343"
   },
   {
@@ -350,7 +411,9 @@ senateData = [
       "Bill"
     ],
     "state": "LA",
-    "middleNames": [],
+    "middleNames": [
+      "Morgan"
+    ],
     "phone": "(202) 224-5824"
   },
   {
@@ -358,7 +421,9 @@ senateData = [
     "firstName": "John",
     "lastName": "Kennedy",
     "state": "LA",
-    "middleNames": [],
+    "middleNames": [
+      "Neely"
+    ],
     "phone": "(202) 224-4623"
   },
   {
@@ -366,7 +431,9 @@ senateData = [
     "firstName": "Elizabeth",
     "lastName": "Warren",
     "state": "MA",
-    "middleNames": [],
+    "middleNames": [
+      "Ann"
+    ],
     "phone": "(202) 224-4543"
   },
   {
@@ -377,7 +444,9 @@ senateData = [
       "Ed"
     ],
     "state": "MA",
-    "middleNames": [],
+    "middleNames": [
+      "John"
+    ],
     "phone": "(202) 224-2742"
   },
   {
@@ -388,7 +457,9 @@ senateData = [
       "Ben"
     ],
     "state": "MD",
-    "middleNames": [],
+    "middleNames": [
+      "Louis"
+    ],
     "phone": "(202) 224-4524"
   },
   {
@@ -407,7 +478,9 @@ senateData = [
     "firstName": "Angus",
     "lastName": "King",
     "state": "ME",
-    "middleNames": [],
+    "middleNames": [
+      "Stanley"
+    ],
     "phone": "(202) 224-5344"
   },
   {
@@ -415,7 +488,9 @@ senateData = [
     "firstName": "Susan",
     "lastName": "Collins",
     "state": "ME",
-    "middleNames": [],
+    "middleNames": [
+      "Margaret"
+    ],
     "phone": "(202) 224-2523"
   },
   {
@@ -426,7 +501,10 @@ senateData = [
       "Debbie"
     ],
     "state": "MI",
-    "middleNames": [],
+    "middleNames": [
+      "Ann"
+      "Greer"
+    ],
     "phone": "(202) 224-4822"
   },
   {
@@ -434,7 +512,9 @@ senateData = [
     "firstName": "Gary",
     "lastName": "Peters",
     "state": "MI",
-    "middleNames": [],
+    "middleNames": [
+      "Charles"
+    ],
     "phone": "(202) 224-6221"
   },
   {
@@ -442,7 +522,9 @@ senateData = [
     "firstName": "Amy",
     "lastName": "Klobuchar",
     "state": "MN",
-    "middleNames": [],
+    "middleNames": [
+      "Jean"
+    ],
     "phone": "(202) 224-3244"
   },
   {
@@ -453,7 +535,9 @@ senateData = [
       "Al"
     ],
     "state": "MN",
-    "middleNames": [],
+    "middleNames": [
+      "Stuart"
+    ],
     "phone": "(202) 224-5641"
   },
   {
@@ -461,7 +545,9 @@ senateData = [
     "firstName": "Roy",
     "lastName": "Blunt",
     "state": "MO",
-    "middleNames": [],
+    "middleNames": [
+      "Dean"
+    ],
     "phone": "(202) 224-5721"
   },
   {
@@ -469,7 +555,9 @@ senateData = [
     "firstName": "Claire",
     "lastName": "McCaskill",
     "state": "MO",
-    "middleNames": [],
+    "middleNames": [
+      "Conner"
+    ],
     "phone": "(202) 224-6154"
   },
   {
@@ -477,15 +565,22 @@ senateData = [
     "firstName": "Roger",
     "lastName": "Wicker",
     "state": "MS",
-    "middleNames": [],
+    "middleNames": [
+      "Frederick"
+    ],
     "phone": "(202) 224-6253"
   },
   {
     "party": "R",
-    "firstName": "Thad",
+    "firstName": "William",
     "lastName": "Cochran",
+    "nicknames": [
+      "Thad"
+    ]
     "state": "MS",
-    "middleNames": [],
+    "middleNames": [
+      "Thad"
+    ],
     "phone": "(202) 224-5054"
   },
   {
@@ -504,7 +599,9 @@ senateData = [
       "Steve"
     ],
     "state": "MT",
-    "middleNames": [],
+    "middleNames": [
+      "David"
+    ],
     "phone": "(202) 224-2651"
   },
   {
@@ -515,7 +612,9 @@ senateData = [
       "Dick"
     ],
     "state": "NC",
-    "middleNames": [],
+    "middleNames": [
+      "Mauze"
+    ],
     "phone": "(202) 224-3154"
   },
   {
@@ -526,7 +625,9 @@ senateData = [
       "Thom"
     ],
     "state": "NC",
-    "middleNames": [],
+    "middleNames": [
+      "Roland"
+    ],
     "phone": "(202) 224-6342"
   },
   {
@@ -534,7 +635,9 @@ senateData = [
     "firstName": "John",
     "lastName": "Hoeven",
     "state": "ND",
-    "middleNames": [],
+    "middleNames": [
+      "Henry"
+    ],
     "phone": "(202) 224-2551"
   },
   {
@@ -545,7 +648,9 @@ senateData = [
       "Heidi"
     ],
     "state": "ND",
-    "middleNames": [],
+    "middleNames": [
+      "Kathryn"
+    ],
     "phone": "(202) 224-2043"
   },
   {
@@ -556,7 +661,9 @@ senateData = [
       "Deb"
     ],
     "state": "NE",
-    "middleNames": [],
+    "middleNames": [
+      "Strobel"
+    ],
     "phone": "(202) 224-6551"
   },
   {
@@ -567,7 +674,9 @@ senateData = [
       "Ben"
     ],
     "state": "NE",
-    "middleNames": [],
+    "middleNames": [
+      "Eric"
+    ],
     "phone": "(202) 224-4224"
   },
   {
@@ -578,7 +687,9 @@ senateData = [
       "Jeanne"
     ],
     "state": "NH",
-    "middleNames": [],
+    "middleNames": [
+      "Jeanne"
+    ],
     "phone": "(202) 224-2841"
   },
   {
@@ -589,7 +700,9 @@ senateData = [
       "Maggie"
     ],
     "state": "NH",
-    "middleNames": [],
+    "middleNames": [
+      "Wood"
+    ],
     "phone": "(202) 224-3324"
   },
   {
@@ -608,7 +721,9 @@ senateData = [
     "firstName": "Cory",
     "lastName": "Booker",
     "state": "NJ",
-    "middleNames": [],
+    "middleNames": [
+      "Anthony"
+    ],
     "phone": "(202) 224-3224"
   },
   {
@@ -616,7 +731,9 @@ senateData = [
     "firstName": "Martin",
     "lastName": "Heinrich",
     "state": "NM",
-    "middleNames": [],
+    "middleNames": [
+      "Trevor"
+    ],
     "phone": "(202) 224-5521"
   },
   {
@@ -627,7 +744,9 @@ senateData = [
       "Tom"
     ],
     "state": "NM",
-    "middleNames": [],
+    "middleNames": [
+      "Stewart"
+    ],
     "phone": "(202) 224-6621"
   },
   {
@@ -635,7 +754,9 @@ senateData = [
     "firstName": "Dean",
     "lastName": "Heller",
     "state": "NV",
-    "middleNames": [],
+    "middleNames": [
+      "Arthur"
+    ],
     "phone": "(202) 224-6244"
   },
   {
@@ -643,7 +764,9 @@ senateData = [
     "firstName": "Catherine",
     "lastName": "Cortez Masto",
     "state": "NV",
-    "middleNames": [],
+    "middleNames": [
+    "Marie",
+  ]
     "phone": "(202) 224-3542"
   },
   {
@@ -654,7 +777,9 @@ senateData = [
       "Chuck"
     ],
     "state": "NY",
-    "middleNames": [],
+    "middleNames": [
+      "Ellis"
+    ],
     "phone": "(202) 224-6542"
   },
   {
@@ -662,7 +787,9 @@ senateData = [
     "firstName": "Kirsten",
     "lastName": "Gillibrand",
     "state": "NY",
-    "middleNames": [],
+    "middleNames": [
+      "Elizabeth"
+    ],
     "phone": "(202) 224-4451"
   },
   {
@@ -673,7 +800,9 @@ senateData = [
       "Rob"
     ],
     "state": "OH",
-    "middleNames": [],
+    "middleNames": [
+      "Jones"
+    ],
     "phone": "(202) 224-3353"
   },
   {
@@ -681,7 +810,9 @@ senateData = [
     "firstName": "Sherrod",
     "lastName": "Brown",
     "state": "OH",
-    "middleNames": [],
+    "middleNames": [
+      "Campbell"
+    ],
     "phone": "(202) 224-2315"
   },
   {
@@ -692,7 +823,9 @@ senateData = [
       "Jim"
     ],
     "state": "OK",
-    "middleNames": [],
+    "middleNames": [
+      "Paul"
+    ],
     "phone": "(202) 224-5754"
   },
   {
@@ -703,7 +836,9 @@ senateData = [
       "Jim"
     ],
     "state": "OK",
-    "middleNames": [],
+    "middleNames": [
+      "Mountain"
+    ],
     "phone": "(202) 224-4721"
   },
   {
@@ -714,7 +849,9 @@ senateData = [
       "Ron"
     ],
     "state": "OR",
-    "middleNames": [],
+    "middleNames": [
+      "Lee"
+    ],
     "phone": "(202) 224-5244"
   },
   {
@@ -725,7 +862,9 @@ senateData = [
       "Jeff"
     ],
     "state": "OR",
-    "middleNames": [],
+    "middleNames": [
+      "Alan"
+    ],
     "phone": "(202) 224-3753"
   },
   {
@@ -736,7 +875,9 @@ senateData = [
       "Pat"
     ],
     "state": "PA",
-    "middleNames": [],
+    "middleNames": [
+      "Joseph"
+    ],
     "phone": "(202) 224-4254"
   },
   {
@@ -747,7 +888,9 @@ senateData = [
       "Bob"
     ],
     "state": "PA",
-    "middleNames": [],
+    "middleNames": [
+      "Patrick"
+    ],
     "phone": "(202) 224-6324"
   },
   {
@@ -755,18 +898,22 @@ senateData = [
     "firstName": "Sheldon",
     "lastName": "Whitehouse",
     "state": "RI",
-    "middleNames": [],
+    "middleNames": [
+      "T"
+    ],
     "phone": "(202) 224-2921"
   },
   {
     "party": "D",
-    "firstName": "Jack",
+    "firstName": "John",
     "lastName": "Reed",
     "nicknames": [
-      "John"
+      "Jack"
     ],
     "state": "RI",
-    "middleNames": [],
+    "middleNames": [
+      "Francis"
+    ],
     "phone": "(202) 224-4642"
   },
   {
@@ -777,7 +924,9 @@ senateData = [
       "Tim"
     ],
     "state": "SC",
-    "middleNames": [],
+    "middleNames": [
+      "Eugene"
+    ],
     "phone": "(202) 224-6121"
   },
   {
@@ -785,7 +934,9 @@ senateData = [
     "firstName": "Lindsey",
     "lastName": "Graham",
     "state": "SC",
-    "middleNames": [],
+    "middleNames": [
+      "Olin"
+    ],
     "phone": "(202) 224-5972"
   },
   {
@@ -793,7 +944,9 @@ senateData = [
     "firstName": "John",
     "lastName": "Thune",
     "state": "SD",
-    "middleNames": [],
+    "middleNames": [
+      "Randolph"
+    ],
     "phone": "(202) 224-2321"
   },
   {
@@ -804,7 +957,9 @@ senateData = [
       "Mike"
     ],
     "state": "SD",
-    "middleNames": [],
+    "middleNames": [
+      "Michael"
+    ],
     "phone": "(202) 224-5842"
   },
   {
@@ -815,7 +970,9 @@ senateData = [
       "Bob"
     ],
     "state": "TN",
-    "middleNames": [],
+    "middleNames": [
+      "Phillips"
+    ],
     "phone": "(202) 224-3344"
   },
   {
@@ -826,7 +983,9 @@ senateData = [
       "Lamar"
     ],
     "state": "TN",
-    "middleNames": [],
+    "middleNames": [
+      "Lamar"
+    ],
     "phone": "(202) 224-4944"
   },
   {
@@ -837,7 +996,9 @@ senateData = [
       "Ted"
     ],
     "state": "TX",
-    "middleNames": [],
+    "middleNames": [
+      "Edward"
+    ],
     "phone": "(202) 224-5922"
   },
   {
@@ -856,7 +1017,9 @@ senateData = [
       "Mike"
     ],
     "state": "UT",
-    "middleNames": [],
+    "middleNames": [
+      "Shumway"
+    ],
     "phone": "(202) 224-5444"
   },
   {
@@ -864,7 +1027,9 @@ senateData = [
     "firstName": "Orrin",
     "lastName": "Hatch",
     "state": "UT",
-    "middleNames": [],
+    "middleNames": [
+      "Grant"
+    ],
     "phone": "(202) 224-5251"
   },
   {
@@ -875,7 +1040,9 @@ senateData = [
       "Tim"
     ],
     "state": "VA",
-    "middleNames": [],
+    "middleNames": [
+      "Michael"
+    ],
     "phone": "(202) 224-4024"
   },
   {
@@ -883,7 +1050,9 @@ senateData = [
     "firstName": "Mark",
     "lastName": "Warner",
     "state": "VA",
-    "middleNames": [],
+    "middleNames": [
+      "Robert"
+    ],
     "phone": "(202) 224-2023"
   },
   {
@@ -894,7 +1063,9 @@ senateData = [
       "Pat"
     ],
     "state": "VT",
-    "middleNames": [],
+    "middleNames": [
+      "Joseph"
+    ],
     "phone": "(202) 224-4242"
   },
   {
@@ -916,7 +1087,9 @@ senateData = [
       "Patty"
     ],
     "state": "WA",
-    "middleNames": [],
+    "middleNames": [
+      "Lynn"
+    ],
     "phone": "(202) 224-2621"
   },
   {
@@ -924,7 +1097,9 @@ senateData = [
     "firstName": "Maria",
     "lastName": "Cantwell",
     "state": "WA",
-    "middleNames": [],
+    "middleNames": [
+      "Elaine"
+    ],
     "phone": "(202) 224-3441"
   },
   {
@@ -935,7 +1110,9 @@ senateData = [
       "Ron"
     ],
     "state": "WI",
-    "middleNames": [],
+    "middleNames": [
+      "Harold"
+    ],
     "phone": "(202) 224-5323"
   },
   {
@@ -943,7 +1120,10 @@ senateData = [
     "firstName": "Tammy",
     "lastName": "Baldwin",
     "state": "WI",
-    "middleNames": [],
+    "middleNames": [
+      "Suzanne",
+      "Green"
+    ],
     "phone": "(202) 224-5653"
   },
   {
@@ -962,7 +1142,9 @@ senateData = [
     "firstName": "Shelley",
     "lastName": "Capito",
     "state": "WV",
-    "middleNames": [],
+    "middleNames": [
+      "Wellons"
+    ],
     "phone": "(202) 224-6472"
   },
   {
@@ -970,7 +1152,9 @@ senateData = [
     "firstName": "John",
     "lastName": "Barrasso",
     "state": "WY",
-    "middleNames": [],
+    "middleNames": [
+      "Anthony"
+    ],
     "phone": "(202) 224-6441"
   },
   {
@@ -981,7 +1165,9 @@ senateData = [
       "Mike"
     ],
     "state": "WY",
-    "middleNames": [],
+    "middleNames": [
+      "Bradley"
+    ],
     "phone": "(202) 224-3424"
   }
 ];

--- a/js/senate.js
+++ b/js/senate.js
@@ -322,9 +322,6 @@ senateData = [
       "Tammy"
     ],
     "state": "IL",
-    "middleNames": [
-      "Tammy"
-    ],
     "phone": "(202) 224-2854"
   },
   {
@@ -980,9 +977,6 @@ senateData = [
       "Lamar"
     ],
     "state": "TN",
-    "middleNames": [
-      "Lamar"
-    ],
     "phone": "(202) 224-4944"
   },
   {

--- a/test/test.js
+++ b/test/test.js
@@ -199,6 +199,34 @@ describe('getRegExpString', function() {
   });
 
 
+  it('optionally matches suffixes', function() {
+    var mockSuffixedCritter = {
+      'firstName': 'Robert',
+      'lastName': 'Corker',
+      'suffix': 'Jr'
+    };
+
+    var regExpString = getRegExpStrings(mockSuffixedCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
+    var permutations = [
+      'Robert Corker',
+      'Robert Corker, Jr',
+      'Robert Corker, Jr.',
+      'Robert Corker Jr',
+      'Robert Corker Jr.',
+      'Corker, Robert',
+      'Corker Jr, Robert',
+      'Corker Jr., Robert',
+      'Corker, Jr, Robert',
+      'Corker, Jr., Robert'
+    ];
+
+    permutations.forEach(function(string) {
+      expect(string.match(re).length).to.equal(1);
+    });
+  });
+
+
   it('matches non-accented variations', function() {
     var mockAccentCritter = {
       'firstName': 'André',

--- a/test/test.js
+++ b/test/test.js
@@ -178,6 +178,27 @@ describe('getRegExpString', function() {
   });
 
 
+  it('matches permutations of multiple last names', function() {
+    var mockMultiLastNameCritter = {
+      'firstName': 'Deborah',
+      'lastName': 'Greer Stabenow'
+    };
+
+    var regExpString = getRegExpStrings(mockMultiLastNameCritter);
+    var re = new RegExp(stringifyRegExpStrings(regExpString), 'ig');
+    var permutations = [
+      'Deborah Greer Stabenow',
+      'Deborah Greer-Stabenow',
+      'Deborah Greer',
+      'Deborah Stabenow'
+    ];
+
+    permutations.forEach(function(string) {
+      expect(string.match(re).length).to.equal(1);
+    });
+  });
+
+
   it('matches non-accented variations', function() {
     var mockAccentCritter = {
       'firstName': 'André',


### PR DESCRIPTION
Thanks to @molly-olmstead for the research. This finishes adding middle names to the senate data, with a few additional features/corrections:

- Fixes logic for suffixes; now instead of a single boolean for "junior", each item can have a single, optional suffix string
- Adds logic for multiple last names; now checks for hyphens as well as only one of multi-worded last names (e.g. Debbie Greer Stabenow)
- Amends unit tests accordingly
