### PR TITLE
Yo dawg, prevent MarkJS from marking already marked marks

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -365,6 +365,7 @@ function markPermutations(lastNames, node) {
     markContext.markRegExp(lastNamesRegExp, {
       element: 'span',
       className: 'dial-congress',
+      exclude: ['.dial-congress'],
       done: function(x) {
         var perfEnd = performance.now();
         var perfTime = Math.round(perfEnd - perfStart) / 1000;


### PR DESCRIPTION
It seems there's a race condition in all the processes, where sometimes a node gets chunked into separate ```foundLastNamesQueue``` items, causing it to get marked twice. This throws JS warnings, because we end up with additional tooltipster instantiations. Using the ```exclude``` option on MarkJS seems to fix things without a noticeable performance hit.