### PR TITLE
Revise content script match pattern and remove unnecessary web resources

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
   },
 
   "content_scripts": [{
-    "matches": ["http://*/*", "https://*/*"],
+    "matches": ["<all_urls>"],
     "css": [
       "bower_components/tooltipster/dist/css/tooltipster.bundle.min.css",
       "bower_components/tooltipster/dist/css/plugins/tooltipster/sideTip/themes/tooltipster-sideTip-noir.min.css",
@@ -52,8 +52,6 @@
   ],
 
   "web_accessible_resources": [
-    "img/icon-38.png",
-    "js/house.json",
-    "js/senate.json"
+    "img/icon-38.png"
   ]
 }


### PR DESCRIPTION
Completes #49.

After double checking the [permission warnings](https://developer.chrome.com/extensions/permission_warnings) info, it seems that we won't be able to remove the "Read and modify all your data on all websites you visit" unless we change the [matches](https://github.com/benjarwar/dial-congress/blob/36a4bb1acd394c5582a75f2d595af5a6191b61c3/manifest.json#L24) pattern to something other than all URLs. But that's precisely what allows us to manipulate the DOM on any page.

Chrome docs say we could leverage the [activeTab](https://developer.chrome.com/extensions/activeTab) API to avoid having such open ended permissions. But that only works if we inject CSS/scripts as a result of the following user actions:

- Executing a browser action
- Executing a page action
- Executing a context menu item
- Executing a keyboard shortcut from the commands API
- Accepting a suggestion from the omnibox API

All of these would require that the user click a button (like an icon in the Chrome toolbar) to activate the extension. I think this severely decreases its usefulness, and would be a high level of effort to boot.

Through this investigation, though, saw an opportunity to refine the ```matches``` value and to remove stale ```web_accessible_resources``` values to removed JSON files.